### PR TITLE
Add numeric value for fake PPP host

### DIFF
--- a/firmware/theoldnet_serial_wifi_modem/theoldnet_serial_wifi_modem.ino
+++ b/firmware/theoldnet_serial_wifi_modem/theoldnet_serial_wifi_modem.ino
@@ -1024,7 +1024,7 @@ void dialOut(String upCmd) {
   host.trim(); // remove leading or trailing spaces
   port.trim();
 
-  if (host.equals("PPP")) {
+  if (host.equals("PPP") || host.equals("777")) {
     if (ppp) {
       Serial.println("PPP already active");
       sendResult(R_ERROR);


### PR DESCRIPTION
Some vintage devices, such as the [Psion 5mx](https://en.wikipedia.org/wiki/Psion_Series_5), have dialers which are restricted to numbers. As an alternative to dialing "PPP" I added support for "777", I chose this number because "P" maps to 7 on an old school phone keypad.

This was inspired by a [thread](https://discord.com/channels/790431789726433320/806680983512154112/981740036573773844) on the The Old Net Discord server.